### PR TITLE
Fix Preview/Publish JavaScript errors in Wordpress 4.x

### DIFF
--- a/includes/ckeditor.utils.js
+++ b/includes/ckeditor.utils.js
@@ -297,6 +297,9 @@ function getTinyMCEObject()
 							window.tinymceosc = func;
 						}
 					},
+					on : function(action, callback){
+						return callback();
+					},
 					getContentAreaContainer : function () {
 						return {
 							offsetHeight : editorCKE.config.height


### PR DESCRIPTION
Fix js errors which occurs after clicking on `Preview Changes`/`Preview` or `Update`/`Publish` buttons.

Some support requests on wordpress.org:
- https://wordpress.org/support/topic/annoying-alert-on-click-publish-in-post
- https://wordpress.org/support/topic/update-page-or-post-confirm-navigation-box-popup
- https://wordpress.org/support/topic/preview-does-not-work
- https://wordpress.org/support/topic/still-unable-to-savepublish-in-wysiwyg-editor
